### PR TITLE
Pr 43 save categories to database

### DIFF
--- a/src/main/java/com/rebalance/controller/CategoryController.java
+++ b/src/main/java/com/rebalance/controller/CategoryController.java
@@ -1,0 +1,44 @@
+package com.rebalance.controller;
+
+import com.rebalance.dto.response.CategoryResponse;
+import com.rebalance.mapper.CategoryMapper;
+import com.rebalance.service.CategoryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Tag(name = "Category management")
+@AllArgsConstructor
+@RestController
+@RequestMapping(APIVersion.current)
+public class CategoryController {
+    private final CategoryService categoryService;
+    private final CategoryMapper categoryMapper;
+
+    @Operation(summary = "Get personal categories")
+    @GetMapping("/personal/categories")
+    public ResponseEntity<List<CategoryResponse>> getPersonalCategories() {
+        return new ResponseEntity<>(
+                categoryService.getPersonalCategories().stream()
+                        .map(categoryMapper::categoryToResponse).collect(Collectors.toList()),
+                HttpStatus.OK);
+    }
+
+    @Operation(summary = "Get categories of group")
+    @GetMapping("/group/{groupId}/categories")
+    public ResponseEntity<List<CategoryResponse>> getGroupCategories(@PathVariable("groupId") Long groupId) {
+        return new ResponseEntity<>(
+                categoryService.getGroupCategories(groupId).stream()
+                        .map(categoryMapper::categoryToResponse).collect(Collectors.toList()),
+                HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/rebalance/controller/GroupExpenseController.java
+++ b/src/main/java/com/rebalance/controller/GroupExpenseController.java
@@ -42,7 +42,8 @@ public class GroupExpenseController {
                 expenseMapper.expenseToGroupResponse(
                         expenseService.saveGroupExpense(
                                 expenseMapper.groupExpenseAddRequestToExpense(request),
-                                expenseMapper.groupExpenseUserRequestListToExpenseUserList(request.getUsers()))),
+                                expenseMapper.groupExpenseUserRequestListToExpenseUserList(request.getUsers()),
+                                request.getCategory())),
                 HttpStatus.OK);
     }
 
@@ -53,7 +54,8 @@ public class GroupExpenseController {
                 expenseMapper.expenseToGroupResponse(
                         expenseService.editGroupExpense(
                                 expenseMapper.groupExpenseEditRequestToExpense(request),
-                                expenseMapper.groupExpenseUserRequestListToExpenseUserList(request.getUsers()))),
+                                expenseMapper.groupExpenseUserRequestListToExpenseUserList(request.getUsers()),
+                                request.getCategory())),
                 HttpStatus.OK);
     }
 

--- a/src/main/java/com/rebalance/controller/PersonalExpenseController.java
+++ b/src/main/java/com/rebalance/controller/PersonalExpenseController.java
@@ -40,7 +40,8 @@ public class PersonalExpenseController {
         return new ResponseEntity<>(
                 expenseMapper.expenseToPersonalResponse(
                         expenseService.savePersonalExpense(
-                                expenseMapper.personalExpenseAddRequestToExpense(request))),
+                                expenseMapper.personalExpenseAddRequestToExpense(request),
+                                request.getCategory())),
                 HttpStatus.OK);
     }
 
@@ -50,7 +51,8 @@ public class PersonalExpenseController {
         return new ResponseEntity<>(
                 expenseMapper.expenseToPersonalResponse(
                         expenseService.editPersonalExpense(
-                                expenseMapper.personalExpenseEditRequestToExpense(request))),
+                                expenseMapper.personalExpenseEditRequestToExpense(request),
+                                request.getCategory())),
                 HttpStatus.OK);
     }
 

--- a/src/main/java/com/rebalance/dto/request/CategoryCreateRequest.java
+++ b/src/main/java/com/rebalance/dto/request/CategoryCreateRequest.java
@@ -1,0 +1,14 @@
+package com.rebalance.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CategoryCreateRequest {
+    @NotNull(message = "Category name is required")
+    private String name;
+}

--- a/src/main/java/com/rebalance/dto/request/CategoryEditRequest.java
+++ b/src/main/java/com/rebalance/dto/request/CategoryEditRequest.java
@@ -1,0 +1,16 @@
+package com.rebalance.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CategoryEditRequest {
+    @NotNull(message = "Category id is required")
+    private Long id;
+    @NotNull(message = "Category name is required")
+    private String name;
+}

--- a/src/main/java/com/rebalance/dto/response/CategoryResponse.java
+++ b/src/main/java/com/rebalance/dto/response/CategoryResponse.java
@@ -1,0 +1,13 @@
+package com.rebalance.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CategoryResponse {
+    private Long id;
+    private String name;
+}

--- a/src/main/java/com/rebalance/entity/Expense.java
+++ b/src/main/java/com/rebalance/entity/Expense.java
@@ -29,8 +29,10 @@ public class Expense {
     @Column(nullable = false)
     private LocalDate date;
 
-    @Column(nullable = false)
-    private String category;
+    @EqualsAndHashCode.Exclude
+    @ManyToOne
+    @JoinColumn(name = "category_id")
+    private GroupCategory category;
 
     @EqualsAndHashCode.Exclude
     @ManyToOne

--- a/src/main/java/com/rebalance/entity/Group.java
+++ b/src/main/java/com/rebalance/entity/Group.java
@@ -45,12 +45,12 @@ public class Group {
     @EqualsAndHashCode.Exclude
     @OneToMany(mappedBy = "group")
     @OnDelete(action = OnDeleteAction.CASCADE)
-    Set<Expense> expenses;
+    private Set<Expense> expenses;
 
     @EqualsAndHashCode.Exclude
     @OneToMany(mappedBy = "group")
     @OnDelete(action = OnDeleteAction.CASCADE)
-    Set<Category> categories;
+    private Set<GroupCategory> categories = new HashSet<>();
 
     public Boolean isPersonalOf(User user) {
         return personal && creator.getId().equals(user.getId());

--- a/src/main/java/com/rebalance/entity/GroupCategory.java
+++ b/src/main/java/com/rebalance/entity/GroupCategory.java
@@ -11,19 +11,28 @@ import java.util.Set;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "categories")
+@Table(name = "group_category")
 @Entity
-public class Category {
+public class GroupCategory {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column
     private Long id;
 
-    @Column(nullable = false)
-    private String name;
+    //TODO: add last used date and sort by it while getting
+
+    @EqualsAndHashCode.Exclude
+    @ManyToOne
+    @JoinColumn(name = "group_id", nullable = false)
+    private Group group;
+
+    @EqualsAndHashCode.Exclude
+    @ManyToOne
+    @JoinColumn(name = "category_id", nullable = false)
+    private Category category;
 
     @EqualsAndHashCode.Exclude
     @OneToMany(mappedBy = "category")
     @OnDelete(action = OnDeleteAction.CASCADE)
-    private Set<GroupCategory> groups;
+    private Set<Expense> expenses;
 }

--- a/src/main/java/com/rebalance/entity/GroupCategory.java
+++ b/src/main/java/com/rebalance/entity/GroupCategory.java
@@ -5,6 +5,7 @@ import lombok.*;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
+import java.time.LocalDateTime;
 import java.util.Set;
 
 @Data
@@ -19,7 +20,8 @@ public class GroupCategory {
     @Column
     private Long id;
 
-    //TODO: add last used date and sort by it while getting
+    @Column
+    private LocalDateTime lastUsed;
 
     @EqualsAndHashCode.Exclude
     @ManyToOne

--- a/src/main/java/com/rebalance/entity/GroupCategory.java
+++ b/src/main/java/com/rebalance/entity/GroupCategory.java
@@ -20,7 +20,7 @@ public class GroupCategory {
     @Column
     private Long id;
 
-    @Column
+    @Column(nullable = false)
     private LocalDateTime lastUsed;
 
     @EqualsAndHashCode.Exclude

--- a/src/main/java/com/rebalance/mapper/CategoryMapper.java
+++ b/src/main/java/com/rebalance/mapper/CategoryMapper.java
@@ -1,0 +1,10 @@
+package com.rebalance.mapper;
+
+import com.rebalance.dto.response.CategoryResponse;
+import com.rebalance.entity.Category;
+import org.mapstruct.Mapper;
+
+@Mapper
+public interface CategoryMapper {
+    CategoryResponse categoryToResponse(Category category);
+}

--- a/src/main/java/com/rebalance/mapper/ExpenseMapper.java
+++ b/src/main/java/com/rebalance/mapper/ExpenseMapper.java
@@ -17,9 +17,11 @@ public interface ExpenseMapper {
     GroupExpenseUserResponse expenseUserToGroupExpenseResponse(ExpenseUsers user);
 
     @Mapping(target = "users", source = "expenseUsers")
+    @Mapping(target = "category", source = "category.category.name")
     GroupExpenseResponse expenseToGroupResponse(Expense expense);
 
 
+    @Mapping(target = "category", source = "category.category.name")
     PersonalExpenseResponse expenseToPersonalResponse(Expense expense);
 
 
@@ -31,14 +33,18 @@ public interface ExpenseMapper {
 
     @Mapping(target = "initiator.id", source = "initiatorUserId")
     @Mapping(target = "group.id", source = "groupId")
+    @Mapping(target = "category", ignore = true)
     Expense groupExpenseAddRequestToExpense(GroupExpenseAddRequest request);
 
+    @Mapping(target = "category", ignore = true)
     Expense personalExpenseAddRequestToExpense(PersonalExpenseAddRequest request);
 
     @Mapping(target = "id", source = "expenseId")
     @Mapping(target = "initiator.id", source = "initiatorUserId")
+    @Mapping(target = "category", ignore = true)
     Expense groupExpenseEditRequestToExpense(GroupExpenseEditRequest request);
 
     @Mapping(target = "id", source = "expenseId")
+    @Mapping(target = "category", ignore = true)
     Expense personalExpenseEditRequestToExpense(PersonalExpenseEditRequest request);
 }

--- a/src/main/java/com/rebalance/repository/CategoryRepository.java
+++ b/src/main/java/com/rebalance/repository/CategoryRepository.java
@@ -1,6 +1,7 @@
 package com.rebalance.repository;
 
 import com.rebalance.entity.Category;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,7 +10,7 @@ import java.util.Optional;
 
 @Repository
 public interface CategoryRepository extends JpaRepository<Category, Long> {
-    List<Category> findAllByGroupsGroupId(Long id);
+    List<Category> findAllByGroupsGroupId(Long id, Sort sort);
 
     Optional<Category> findByNameLike(String name);
 }

--- a/src/main/java/com/rebalance/repository/CategoryRepository.java
+++ b/src/main/java/com/rebalance/repository/CategoryRepository.java
@@ -4,7 +4,12 @@ import com.rebalance.entity.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Optional;
+
 @Repository
 public interface CategoryRepository extends JpaRepository<Category, Long> {
+    List<Category> findAllByGroupsGroupId(Long id);
 
+    Optional<Category> findByNameLike(String name);
 }

--- a/src/main/java/com/rebalance/repository/GroupCategoryRepository.java
+++ b/src/main/java/com/rebalance/repository/GroupCategoryRepository.java
@@ -1,0 +1,14 @@
+package com.rebalance.repository;
+
+import com.rebalance.entity.Category;
+import com.rebalance.entity.Group;
+import com.rebalance.entity.GroupCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface GroupCategoryRepository extends JpaRepository<GroupCategory, Long> {
+    Optional<GroupCategory> findByCategoryAndGroup(Category category, Group group);
+}

--- a/src/main/java/com/rebalance/security/HttpConfiguration.java
+++ b/src/main/java/com/rebalance/security/HttpConfiguration.java
@@ -37,6 +37,10 @@ public class HttpConfiguration {
                         .requestMatchers(HttpMethod.POST, APIVersion.current + "/user/login").permitAll()
                         .requestMatchers(HttpMethod.POST, APIVersion.current + "/user/logout").authenticated()
 
+                        // CategoryController
+                        .requestMatchers(HttpMethod.GET, APIVersion.current + "/personal/categories").authenticated()
+                        .requestMatchers(HttpMethod.GET, APIVersion.current + "/group/*/categories").authenticated()
+
                         // GroupController
                         .requestMatchers(HttpMethod.GET, APIVersion.current + "/group/*/users").authenticated()
                         .requestMatchers(HttpMethod.GET, APIVersion.current + "/group/*").authenticated()

--- a/src/main/java/com/rebalance/service/CategoryService.java
+++ b/src/main/java/com/rebalance/service/CategoryService.java
@@ -1,0 +1,47 @@
+package com.rebalance.service;
+
+import com.rebalance.entity.Category;
+import com.rebalance.entity.Group;
+import com.rebalance.entity.GroupCategory;
+import com.rebalance.entity.User;
+import com.rebalance.repository.CategoryRepository;
+import com.rebalance.repository.GroupCategoryRepository;
+import com.rebalance.security.SignedInUsernameGetter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class CategoryService {
+    private final CategoryRepository categoryRepository;
+    private final GroupCategoryRepository groupCategoryRepository;
+    private final SignedInUsernameGetter signedInUsernameGetter;
+    private final GroupService groupService;
+
+    public List<Category> getPersonalCategories() {
+        User signedInUser = signedInUsernameGetter.getUser();
+        Group personalGroup = groupService.getPersonalGroupByUserId(signedInUser.getId());
+        return categoryRepository.findAllByGroupsGroupId(personalGroup.getId());
+    }
+
+    public List<Category> getGroupCategories(Long groupId) {
+        Group group = groupService.getNotPersonalGroupById(groupId);
+        return categoryRepository.findAllByGroupsGroupId(group.getId());
+    }
+
+    private Category getOrCreateCategory(String name) {
+        return categoryRepository.findByNameLike(name)
+                .orElseGet(() -> categoryRepository.save(
+                        Category.builder().name(name).build()));
+    }
+
+    public GroupCategory getOrCreateGroupCategory(String categoryName, Group group) {
+        Category category = getOrCreateCategory(categoryName);
+
+        return groupCategoryRepository.findByCategoryAndGroup(category, group)
+                .orElseGet(() -> groupCategoryRepository.save(
+                        GroupCategory.builder().category(category).group(group).build()));
+    }
+}

--- a/src/main/java/com/rebalance/service/CategoryService.java
+++ b/src/main/java/com/rebalance/service/CategoryService.java
@@ -44,7 +44,7 @@ public class CategoryService {
 
         GroupCategory groupCategory = groupCategoryRepository.findByCategoryAndGroup(category, group)
                 .orElseGet(() -> groupCategoryRepository.save(
-                        GroupCategory.builder().category(category).group(group).build()));
+                        GroupCategory.builder().category(category).group(group).lastUsed(LocalDateTime.now()).build()));
 
         groupCategory.setLastUsed(LocalDateTime.now());
         groupCategoryRepository.save(groupCategory);

--- a/src/main/resources/db/migration/V6__add_expense_category_and_fix_expense.sql
+++ b/src/main/resources/db/migration/V6__add_expense_category_and_fix_expense.sql
@@ -1,0 +1,37 @@
+ALTER TABLE expenses
+    ADD CONSTRAINT FK_EXPENSES_ON_ADDED_BY FOREIGN KEY (added_by_id) REFERENCES users (id);
+
+
+DROP TABLE categories;
+
+CREATE TABLE categories
+(
+    id   BIGINT AUTO_INCREMENT NOT NULL,
+    name VARCHAR(255)          NOT NULL,
+    CONSTRAINT pk_categories PRIMARY KEY (id)
+);
+
+
+CREATE TABLE group_category
+(
+    id          BIGINT AUTO_INCREMENT NOT NULL,
+    group_id    BIGINT                NOT NULL,
+    category_id BIGINT                NOT NULL,
+    CONSTRAINT pk_group_category PRIMARY KEY (id)
+);
+
+ALTER TABLE group_category
+    ADD CONSTRAINT FK_GROUP_CATEGORY_ON_CATEGORY FOREIGN KEY (category_id) REFERENCES categories (id) ON DELETE CASCADE;
+
+ALTER TABLE group_category
+    ADD CONSTRAINT FK_GROUP_CATEGORY_ON_GROUP FOREIGN KEY (group_id) REFERENCES app_group (id) ON DELETE CASCADE;
+
+
+ALTER TABLE expenses
+    DROP COLUMN `category`;
+
+ALTER TABLE expenses
+    ADD category_id BIGINT;
+
+ALTER TABLE expenses
+    ADD CONSTRAINT FK_EXPENSES_ON_CATEGORY FOREIGN KEY (category_id) REFERENCES group_category (id) ON DELETE CASCADE;

--- a/src/main/resources/db/migration/V6__add_expense_category_and_fix_expense.sql
+++ b/src/main/resources/db/migration/V6__add_expense_category_and_fix_expense.sql
@@ -15,6 +15,7 @@ CREATE TABLE categories
 CREATE TABLE group_category
 (
     id          BIGINT AUTO_INCREMENT NOT NULL,
+    last_used   datetime              NOT NULL,
     group_id    BIGINT                NOT NULL,
     category_id BIGINT                NOT NULL,
     CONSTRAINT pk_group_category PRIMARY KEY (id)


### PR DESCRIPTION
- Added intermediate table GroupCategory to make many-to-many relations from Category to Group
- Modified Expense to link GroupCategory as category
- Created Category controller and service to get previously used personal and group categories (in the order of last usage)
- Adapted existing Expense saving mechanism to use new Category mechanism
- Added missing FK in Expense